### PR TITLE
Adjust path in require statement to work with Ruby 1.9.2 and later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.[ao]
+/test
+/vtparse_table.[ch]

--- a/vtparse_check_tables.rb
+++ b/vtparse_check_tables.rb
@@ -1,5 +1,5 @@
 
-require 'vtparse_tables'
+require './vtparse_tables'
 
 #
 # check that for every state, there is a transition defined

--- a/vtparse_gen_c_tables.rb
+++ b/vtparse_gen_c_tables.rb
@@ -1,5 +1,5 @@
 
-require 'vtparse_tables'
+require './vtparse_tables'
 
 class String
     def pad(len)


### PR DESCRIPTION
In Ruby 1.9.2 and later, the current directory has been removed from the
LOAD_PATH, due to security reasons. This causes an error when running make. The
solution is to prefix the module name with ./ to force it to be loaded from the
current directory.
